### PR TITLE
Specify optional deps in pyproject.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,12 @@ pip install .
 ```
 
 ## Documentation
-The documentation can be accessed [online](https://tightbinder.readthedocs.io/en/latest/). To build it, you must have installed GNU Make and the library itself. 
-To do so, ```cd docs/``` and first install the required dependencies with ```pip install -r requirements.txt```. Then, run ```make html``` to build the documentation. It will be created in ```docs/build/html```, and can be accessed through ```index.html```.
+The documentation can be accessed [online](https://tightbinder.readthedocs.io/en/latest/). To build it, you must have installed GNU Make and the library itself. Additional requirements to build documentation can be installed by specifying docs qualifier when installing tightbinder
+```
+cd {path}/tightbinder
+pip install ".[docs]"
+```
+Then, ```cd docs/``` and then, run ```make html``` to build the documentation. It will be created in ```docs/build/html```, and can be accessed through ```index.html```.
 
 ## Contributing
 The library is still under development as new features and optimizations are added. Therefore, any kind of contribution is welcome, from completing the documentation, bug fixing, adding new features or reporting bugs of the library.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,0 @@
-sphinx
-pydata-sphinx-theme
-sphinx-autodoc-typehints
-sphinx_rtd_theme

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,17 @@ dependencies = [
 "Homepage" = "https://github.com/alejandrojuria/tightbinder"
 "Bug Reports" = "https://github.com/alejandrojuria/tightbinder/issues"
 
+[project.optional-dependencies]
+tests = [
+  "pytest"
+]
+docs = [
+  "sphinx",
+  "pydata-sphinx-theme",
+  "sphinx-autodoc-typehints",
+  "sphinx_rtd_theme"
+]
+
 [tool.setuptools.packages.find]
 where = ["src"]
 


### PR DESCRIPTION
You can specify the optional dependencies for tests and docs in pyproject.toml itself.

I haven't updated the README in tests to reflect the new approach. 